### PR TITLE
Fix tests by making sure PrismaClient is initialized

### DIFF
--- a/tests/controllers/contract_data.test.ts
+++ b/tests/controllers/contract_data.test.ts
@@ -12,7 +12,9 @@ describe("GET /api/:network/contract/:contract_id/storage", () => {
   beforeAll(async () => {
     testPrismaClient = global.testPrismaClient;
     if (!testPrismaClient) {
-      throw new Error("global.testPrismaClient is not initialized. Check tests/setup.ts");
+      throw new Error(
+        "global.testPrismaClient is not initialized. Check tests/setup.ts",
+      );
     }
     await seedTestData(testPrismaClient);
   });

--- a/tests/test-data-seeder.ts
+++ b/tests/test-data-seeder.ts
@@ -19,7 +19,9 @@ export interface TestContractData {
 export async function seedTestData(prisma: PrismaClient): Promise<void> {
   // Ensure prisma client is initialized
   if (!prisma) {
-    throw new Error("PrismaClient is not initialized. Make sure tests/setup.ts has completed.");
+    throw new Error(
+      "PrismaClient is not initialized. Make sure tests/setup.ts has completed.",
+    );
   }
 
   // Clear existing data (handle missing tables gracefully)


### PR DESCRIPTION
Fixing `cannot read properties of undefined` error I saw in [this PR](https://github.com/stellar/laboratory-backend/actions/runs/19056860711/job/54500187086)
