### PR TITLE
Use private connection to cloudsql instances

### DIFF
--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -99,7 +99,7 @@ async function connect({
 
   await gCloudSqlConnector.startLocalProxy({
     instanceConnectionName,
-    ipType: IpAddressTypes.PUBLIC,
+    ipType: IpAddressTypes.PRIVATE,
     authType: AuthTypes.IAM,
     listenOptions: { path: gCloudSqlSocketPath },
   });


### PR DESCRIPTION
The cloudsql instances that we are using in gcp are all connected to via private IPs

This changes the sql connection config to use a private IP for the cloudsql connections
