### PR TITLE
enable the CORS middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "@prisma/client": "^6.19.0",
     "@sentry/node": "^10.38.0",
     "@stellar/stellar-sdk": "^14.5.0",
+    "cors": "^2.8.6",
     "express": "^5.2.1",
     "zod": "^4.1.13"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@testcontainers/postgresql": "^11.9.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@stellar/stellar-sdk':
         specifier: ^14.5.0
         version: 14.5.0
+      cors:
+        specifier: ^2.8.6
+        version: 2.8.6
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -39,6 +42,9 @@ importers:
       '@testcontainers/postgresql':
         specifier: ^11.9.0
         version: 11.9.0
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -828,6 +834,9 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/docker-modem@3.0.6':
     resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
 
@@ -1433,6 +1442,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
@@ -2385,6 +2398,10 @@ packages:
     resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -4103,6 +4120,10 @@ snapshots:
     dependencies:
       '@types/node': 24.10.1
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 24.10.1
+
   '@types/docker-modem@3.0.6':
     dependencies:
       '@types/node': 24.10.1
@@ -4760,6 +4781,11 @@ snapshots:
   cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cpu-features@0.0.10:
     dependencies:
@@ -5900,6 +5926,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       tinyexec: 1.0.2
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Sentry must be imported first to properly instrument all modules
 import { Sentry } from "./instrument";
 
+import cors from "cors";
 import type { NextFunction, Request, Response } from "express";
 import express from "express";
 
@@ -13,6 +14,32 @@ import { connect } from "./utils/connect";
 const app = express();
 
 const PORT = Env.port;
+
+// CORS configuration
+const allowedOrigins = [
+  "https://laboratory.stellar.org",
+  "http://localhost:3000",
+  "http://localhost:3001",
+];
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      // Allow requests with no origin (e.g., curl, Postman, server-to-server)
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+      if (allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    methods: ["GET", "OPTIONS"],
+    allowedHeaders: ["Content-Type"],
+  }),
+);
 
 app.use(express.json());
 


### PR DESCRIPTION
I can't access the backend endpoint due to the CORS policy. This enables the CORS middleware with the following `allowedOrigins: "https://laboratory.stellar.org", "http://localhost:3000", "http://localhost:3001",`.


Test | Origin | Result
-- | -- | --
Allowed origin | https://laboratory.stellar.org | ✅ Access-Control-Allow-Origin: https://laboratory.stellar.org
Localhost | http://localhost:3001 | ✅ Access-Control-Allow-Origin: http://localhost:3001
Blocked origin | https://evil-site.com | ✅ Rejected (500 error, no CORS header)
Preflight OPTIONS | https://laboratory.stellar.org | ✅ Returns all headers: Allow-Methods: GET,OPTIONS, Allow-Headers: Content-Type
