### PR TITLE
fix: drop vulnerable uuid via dockerode override

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
       "js-yaml": "^4.1.1",
       "glob": "^13.0.0",
       "axios": "^1.15.0",
-      "protobufjs": ">=7.5.5"
+      "protobufjs": ">=7.5.5",
+      "dockerode": "^5.0.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   glob: ^13.0.0
   axios: ^1.15.0
   protobufjs: '>=7.5.5'
+  dockerode: ^5.0.0
 
 importers:
 
@@ -1620,13 +1621,13 @@ packages:
     resolution: {integrity: sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w==}
     engines: {node: '>= 6.0.0'}
 
-  docker-modem@5.0.6:
-    resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
     engines: {node: '>= 8.0'}
 
-  dockerode@4.0.9:
-    resolution: {integrity: sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==}
-    engines: {node: '>= 8.0'}
+  dockerode@5.0.0:
+    resolution: {integrity: sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==}
+    engines: {node: '>= 14.17'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3240,10 +3241,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -5107,7 +5104,7 @@ snapshots:
     dependencies:
       yaml: 2.8.3
 
-  docker-modem@5.0.6:
+  docker-modem@5.0.7:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       readable-stream: 3.6.2
@@ -5116,15 +5113,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@4.0.9:
+  dockerode@5.0.0:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.2
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.6
+      docker-modem: 5.0.7
       protobufjs: 8.0.1
       tar-fs: 2.1.4
-      uuid: 10.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6833,7 +6829,7 @@ snapshots:
       byline: 5.0.0
       debug: 4.4.3(supports-color@5.5.0)
       docker-compose: 1.3.1
-      dockerode: 4.0.9
+      dockerode: 5.0.0
       get-port: 7.1.0
       proper-lockfile: 4.1.2
       properties-reader: 3.0.1
@@ -7018,8 +7014,6 @@ snapshots:
   url-template@2.0.8: {}
 
   util-deprecate@1.0.2: {}
-
-  uuid@10.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## What
Add `dockerode: ^5.0.0` to `pnpm.overrides`. dockerode 5.0.0 dropped its `uuid` dependency entirely, so the vulnerable `uuid@10.0.0` (transitively pulled in by `@testcontainers/postgresql` → `testcontainers` → `dockerode`) is no longer in the tree.

## Why

Resolves Dependabot alert [#60](https://github.com/stellar/laboratory-backend/security/dependabot/60) — `uuid <14.0.0` (GHSA-w5hq-g745-h8pq, medium): missing buffer bounds check in v3/v5/v6 when `buf` is provided.

Why this approach instead of the obvious alternatives:

- **Bump direct parent (`@testcontainers/postgresql`)** — latest 11.14.0 still pins `dockerode@^4.0.10`, which still depends on `uuid@^10`. No upstream fix yet.
- **Override `uuid` to `^14`** — uuid 14 is pure ESM (`"type": "module"`, no CJS export). It breaks `dockerode@4.x`'s `require("uuid").v4` under Jest (`SyntaxError: Unexpected token 'export'`).
- **Override `dockerode` to `^5.0.0`** *(chosen)* — release notes are limited to "dropped uuid package" + node minimum bumped to `>= 14.17` (we already require Node 22). Smallest change that removes the vulnerable dep entirely.

## Verification

```
pnpm audit       → No known vulnerabilities found
pnpm run build   → clean
pnpm test        → 6 suites, 129 tests passing
pnpm why uuid    → (empty — uuid no longer in dependency tree)
```